### PR TITLE
Make default org name for iOS template less generic

### DIFF
--- a/iOSIDPTemplate/Authenticator.xcodeproj/project.pbxproj
+++ b/iOSIDPTemplate/Authenticator.xcodeproj/project.pbxproj
@@ -184,7 +184,7 @@
 			attributes = {
 				LastSwiftUpdateCheck = 0710;
 				LastUpgradeCheck = 0920;
-				ORGANIZATIONNAME = Salesforce;
+				ORGANIZATIONNAME = SFDCAuthenticator;
 				TargetAttributes = {
 					4FD6C4731B754AF1002F9F90 = {
 						CreatedOnToolsVersion = 6.4;

--- a/iOSIDPTemplate/template.js
+++ b/iOSIDPTemplate/template.js
@@ -38,7 +38,7 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
     // Values in template
     var templateAppName =  'Authenticator';
     var templatePackageName = 'com.salesforce.Authenticator';
-    var templateOrganization = 'SFDCAuthenticator';
+    var templateOrganization = 'Authenticator';
 
     // Key files
     var templatePodfile = 'Podfile';

--- a/iOSIDPTemplate/template.js
+++ b/iOSIDPTemplate/template.js
@@ -38,7 +38,7 @@ function prepare(config, replaceInFiles, moveFile, removeFile) {
     // Values in template
     var templateAppName =  'Authenticator';
     var templatePackageName = 'com.salesforce.Authenticator';
-    var templateOrganization = 'Authenticator';
+    var templateOrganization = 'SFDCAuthenticator';
 
     // Key files
     var templatePodfile = 'Podfile';


### PR DESCRIPTION
Yesterday I tried to build an app with forceios createwithtemplate and the iOS IDP template. For app name, I entered "TestAuthenticator", and for organization name, "BestApps". Unfortunately, the app creation failed because the template script overwrote "Authenticator" in the project folder name with "BestApps", resulting in "TestBestApps" instead of "TestAuthenticator", and then CocoaPods couldn't find the target it expected.

Since it seems likely to me that lots of apps created with this template actually will use "Authenticator" in the app name, I changed the template to use "SFDCAuthenticator" as the default organization. 

The Android template didn't have this issue.